### PR TITLE
Fix crash?

### DIFF
--- a/init.lua
+++ b/init.lua
@@ -17,6 +17,8 @@ minetest.register_on_joinplayer(function (player)
     end,player)
 end)
 minetest.register_on_chat_message(function(name,message)
+    if not PLAYERS_MSG[name] then return end
+
     for msg,info in pairs(PLAYERS_MSG[name]) do
         if minetest.get_us_time()-info[2] >= RESET_TIME_MSECS then
             PLAYERS_MSG[name][msg]=nil


### PR DESCRIPTION
Might need closer looking into 
```
2021-04-28 16:16:13: ERROR[Main]: ServerError: AsyncErr: ServerThread::run Lua: Runtime error from mod 'sauth' in callback on_chat_message(): ...etest/worlds/ctf//worldmods/servermods/antispam/init.lua:20: bad argument #1 to 'pairs' (table expected, got nil)
2021-04-28 16:16:13: ERROR[Main]: stack traceback:
2021-04-28 16:16:13: ERROR[Main]:     [C]: in function 'pairs'
2021-04-28 16:16:13: ERROR[Main]:     ...etest/worlds/ctf//worldmods/servermods/antispam/init.lua:20: in function 'func'
2021-04-28 16:16:13: ERROR[Main]:     ...minetest/games/capturetheflag/mods/ctf/ctf_chat/init.lua:309: in function <...minetest/games/capturetheflag/mods/ctf/ctf_chat/init.lua:305>
```